### PR TITLE
Update Soccer Streams subreddits after they split

### DIFF
--- a/resources/lib/modules/subreddit_lists.py
+++ b/resources/lib/modules/subreddit_lists.py
@@ -1,6 +1,7 @@
 
 streaming_subreddits = [
-{'name': 'Soccer Streams', 'url': 'soccerstreams'},
+{'name': 'Soccer Streams EPL', 'url': 'soccerstreams_pl'},
+{'name': 'Soccer Streams Other', 'url': 'soccerstreams_other'},
 {'name': 'MMA Streams', 'url': 'MMAStreams'},
 {'name': 'NFL Streams', 'url': 'NFLStreams'},
 {'name': 'NBA Streams', 'url': 'nbastreams'},


### PR DESCRIPTION
According to
/r/soccerstreams/comments/ahk9uk/important_announcement_about_the_future_of_this/
the /r/soccerstreams subreddit has now split:

New subreddits: /r/soccerstreams_pl for EPL links, and /r/soccerstreams_other for ALL other leagues.